### PR TITLE
Change title color on shift press

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -11,6 +11,7 @@ class View {
     this.demo2 = this.demo2.bind(this);
     this.demo3 = this.demo3.bind(this);
     this.demo4 = this.demo4.bind(this);
+    this.changeColors = this.changeColors.bind(this)
     window.addEventListener("keydown", this.handleKeyEvent.bind(this));
   }
 
@@ -29,6 +30,9 @@ class View {
           break;
         case 40:
           this.demo4();
+          break;
+        case 16:
+          this.changeColors();
           break;
         case 27:
           this.setUpBoard();
@@ -140,6 +144,11 @@ class View {
     this.setUpButtons();
     const $gl0title = $gl0('h1');
     $gl0title.addClass('tada');
+  }
+
+  changeColors() {
+    const $gl0title = $gl0('h1');
+    $gl0title.css('color', `${this.randomColorString()}`)
   }
 
 }


### PR DESCRIPTION
Hitting shift changes the color of the "GLO" title.
Hitting one of the arrow keys will reset "GLO" back to its original color.